### PR TITLE
Include the body of a post in the JSON response

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -133,7 +133,7 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     respond_to do |format|
       format.html # show.html.erb
-      format.json { render json: @post.subtree }
+      format.json { @post.body; render json: @post }
     end
   end
 


### PR DESCRIPTION
Closes #8

(as a note, the inclusion of non-thread-roots in the front page JSON and Atom feeds should probably be considered)