### PR TITLE
Fix "expand post" not restoring enough space in some cases.

### DIFF
--- a/app/assets/javascripts/posts.js.coffee
+++ b/app/assets/javascripts/posts.js.coffee
@@ -23,12 +23,11 @@ window.add_show_more_links = () ->
 #        console.log(div.height())
 #        console.log(div.html())
         if div.height() > (14 * 10)
-            div.data("oldHeight", div.height())
             div.height(14 * 10)
             div.css("overflow", "hidden")
             link_span.html("<br><a href=\"javascript:void(0)\">Expand this post &rarr;</a><br>")
             link_span.children("a").click (event) ->
-                div.height(div.data("oldHeight"))
+                div.height("auto")
                 div.css("overflow", "visible")
                 link_span.html("")
                 event.preventDefault()


### PR DESCRIPTION
In some cases, the saved oldHeight could have become inaccurate due
to, for example, loaded images. This commit fixes this issue by
reverting the property to its default value of "auto" instead.