### PR TITLE
Restore show more state correctly on back button press.

### DIFF
--- a/app/assets/javascripts/posts.js.coffee
+++ b/app/assets/javascripts/posts.js.coffee
@@ -20,15 +20,16 @@ window.add_show_more_links = () ->
     $('.show-more-link').each () ->
         link_span = $(this)
         div = link_span.parent().children(".post-body")
-#        console.log(div.height())
-#        console.log(div.html())
-        if div.height() > (14 * 10)
+        if (div.height() > (14 * 10) && div.attr("data-show-more-state") != "expanded")\
+          || div.attr("data-show-more-state") == "unexpanded"
             div.height(14 * 10)
             div.css("overflow", "hidden")
+            div.attr("data-show-more-state", "unexpanded")
             link_span.html("<br><a href=\"javascript:void(0)\">Expand this post &rarr;</a><br>")
             link_span.children("a").click (event) ->
                 div.height("auto")
                 div.css("overflow", "visible")
+                div.attr("data-show-more-state", "expanded")
                 link_span.html("")
                 event.preventDefault()
                 return false


### PR DESCRIPTION
The way we initialized the show more links would cause them to break
if you went to another post and hit the back, since the event handler
wouldn't get installed on the subsequent turbolinks:load due to teh
div hight being <= 140 px.

This also led to posts that had been expanded being de-expanded after
returning to the page.

This commit resolves both issues.