### PR TITLE
Make per-site configuration more centralized

### DIFF
--- a/app/mailers/board_mailer.rb
+++ b/app/mailers/board_mailer.rb
@@ -15,7 +15,7 @@ class BoardMailer < ActionMailer::Base
     @post = new_reply
     @parent = post_watched
     mail(:to => "#{@user.name} <#{@user.email}>", 
-         :subject => "New reply to \"#{@parent.subject}\" on the PPC Board") do |format|
+         :subject => "New reply to \"#{@parent.subject}\" on the #{SITE_CONFIG[:title]}") do |format|
       format.text
       format.html
     end

--- a/app/mailers/board_mailer.rb
+++ b/app/mailers/board_mailer.rb
@@ -1,5 +1,5 @@
 class BoardMailer < ActionMailer::Base
-  default from: "system@#{Rails.application.config.mail_host}"
+  default from: "system@#{SITE_CONFIG[:mail_host]}"
   
   def welcome_email(user)
     @user = user

--- a/app/views/bans/show.html.erb
+++ b/app/views/bans/show.html.erb
@@ -18,5 +18,5 @@ that is, for
 </p>
 <p>
 If you believe you've been banned in error, please
-contact the Board admin at <&= mail_to(Ralis.application.config.admin_contact) %>
+contact the Board admin at <&= mail_to(SITE_CONFIG[:admin_contact]) %>
 </p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <head>
   <title><%= content_for(:title) ? yield(:title) : "Index" %>
-         - PPC Posting Board</title>
+         - <%= SITE_CONFIG[:title] %></title>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -34,7 +34,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="<%= root_path %>">PPC Posting Board</a>
+      <a class="navbar-brand" href="<%= root_path %>"><%= SITE_CONFIG[:title] %></a>
     </div>
     <div class="collapse navbar-collapse" id="nav-collapse-header-all">
       <ul class="nav navbar-nav navbar-left">

--- a/app/views/pages/_data_collection.html.erb
+++ b/app/views/pages/_data_collection.html.erb
@@ -15,5 +15,5 @@
   We record your <strong>IP address</strong> so that the Nameless Admin can enforce the bans and otherwise maintain the integrity of the Board and the community.
 </p>
 <p>
-  Things that are posted to the board can only be deleted by the Nameless Admin. To contact them, please email <%= mail_to Rails.application.config.admin_contact %>.
+  Things that are posted to the board can only be deleted by the Nameless Admin. To contact them, please email <%= mail_to SITE_CONFIG[:admin_contact] %>.
 </p>

--- a/app/views/pages/formatting_help.html.erb
+++ b/app/views/pages/formatting_help.html.erb
@@ -1,7 +1,7 @@
 <% title("Formatting Help") %>
-<h1>Formatting Help for the PPC Board</h1>
+<h1>Formatting Help for the <%= SITE_CONFIG[:title] %></h1>
 <p>
-In posts on the PPC Board, you can use a combination of 
+In posts on this Board, you can use a combination of
 <a href="http://daringfireball.net/projects/markdown/basics">Markdown</a>
 and HTML to write your post.
 </p>

--- a/app/views/posts/_header.html.erb
+++ b/app/views/posts/_header.html.erb
@@ -1,9 +1,9 @@
 <div class="top-matter">
-<% if Rails.application.config.banner_kind == :devel %>
+<% if SITE_KIND == :devel %>
 <p>
-<strong><u><span style="font-size:large;">THIS IS A DEVELOPMENT INSTANCE FOR THE PPC BOARD. TO CONFIGURE THIS MESSAGE, SEE app/views/posts/_header.html.erb and config/</span></u></strong>
+<strong><u><span style="font-size:large;">THIS IS A DEVELOPMENT INSTANCE FOR THE PPC BOARD.</span></u></strong>
 </p>
-<% elsif Rails.application.config.banner_kind == :rp %>
+<% elsif SITE_KIND == :rp %>
 <p>
 This is the RP and backup Board for the Protectors of the Plot Continuum. <strong>Our main board is at</strong> <a href="https://www.plotprotectors.org/">https://www.plotprotectors.org/</a>
 </p>

--- a/app/views/posts/index.atom.builder
+++ b/app/views/posts/index.atom.builder
@@ -1,5 +1,5 @@
 atom_feed do |feed|
-  feed.title("Threads from the PPC Posting Board")
+  feed.title("Threads from the #{SITE_CONFIG[:title]}")
   feed.updated(Post.order("created_at DESC").first.created_at ) if @posts.length > 0
 
   @posts.each do |post|

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,4 +1,4 @@
-<h1>The PPC Posting Board</h1>
+<h1>The <%= SITE_CONFIG[:title]%></h1>
 <%= render 'header' %>
 
 <ul class="nav nav-tabs">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,7 +1,7 @@
 <% title(@user.name) %>
 <h1><%= @user.name %></h1>
 <% if @user.moderator %>
-<p><%= @user.name %> is a moderator of the PPC Board</p>
+<p><%= @user.name %> is a moderator of the <%= SITE_CONFIG[:title] %></p>
 <% end %>
 <% if @user.show_email || (user_signed_in? && current_user.moderator?) %>
 <p><a href="mailto:<%= @user.email %>">Email <%= @user.name %></a></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,18 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+SITE_KIND = :devel
+if ENV["BOARD_SITE"]
+  SITE_KIND = ENV["BOARD_SITE"].to_sym
+end
+
+SITE_CONFIG = HashWithIndifferentAccess.new(
+  YAML.load_file(File.expand_path('../../config/sites.yml', __FILE__)))[SITE_KIND]
+
+unless SITE_CONFIG.key?(:mail_host)
+  SITE_CONFIG[:mail_host] = SITE_CONFIG[:app_host]
+end
+
 module PPCBoard20
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -19,7 +31,5 @@ module PPCBoard20
     config.active_record.schema_format = :sql
 
     config.time_zone = "UTC"
-
-    config.banner_kind = :devel
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -69,12 +69,10 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
   config.action_mailer.delivery_method = :file
-  config.mail_host = "localhost"
   # Mailer host
   config.action_mailer.default_url_options = {
-    :host => 'localhost',
+    :host => SITE_CONFIG[:app_host],
     :port => '3000',
     :only_path => false
   }
-  config.admin_contact = "admin@localhost"
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 Rails.application.configure do
-  if ENV["RAILS_STAGING"]
+  if ENV["RAILS_STAGING"] || SITE_KIND == :rp
       Rails.application.credentials.merge!(Rails.application.credentials.staging)
   end
   # Settings specified here will take precedence over those in config/application.rb.
@@ -104,21 +104,8 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  if ENV["RP_BOARD"]
-    config.banner_kind = :rp
-  else
-    config.banner_kind = :none
-  end
-
-  config.admin_contact = ENV["ADMIN_CONTACT"] || nil
-  config.mail_host = ENV["MAIL_HOST"] || nil
-
-  if config.mail_host == nil or config.admin_contact == nil
-    raise Exception.new "Mail hostname or admin contact unconfigured"
-  end
-
   config.action_mailer.default_url_options = {
-    :host => config.mail_host,
+    :host => SITE_CONFIG[:app_host],
     :only_path => false }
 
   if ENV['SENDGRID_USERNAME'] && ENV['SENDGRID_PASSWORD']
@@ -136,7 +123,7 @@ Rails.application.configure do
     config.action_mailer.delivery_method = :mailgun
     config.action_mailer.mailgun_settings = {
       api_key: Rails.application.credentials.mailgun_key,
-      domain: config.mail_host,
+      domain: SITE_CONFIG[:mail_host],
   }
   else
     config.action_mailer.delivery_method = :file

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,12 +45,10 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.mail_host = "localhost"
   # Mailer host
   config.action_mailer.default_url_options = {
     :host => 'localhost',
     :port => '3000',
     :only_path => false
   }
-  config.admin_contact = "admin@test.invalid"
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -16,7 +16,7 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
-  config.mailer_sender = "system@#{Rails.application.config.mail_host}"
+  config.mailer_sender = "system@#{SITE_CONFIG[:mail_host]}"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/sites.yml
+++ b/config/sites.yml
@@ -1,0 +1,13 @@
+devel:
+  title: Development PPC Posting Board
+  app_host: localhost
+  admin_contact: example@place.invalid
+main:
+  title: PPC Posting Board
+  app_host: www.plotprotectors.org
+  mail_host: mg.plotprotectors.org
+  admin_contact: admin@mg.plotprotectors.org
+rp:
+  title: PPC Roleplay Board
+  app_host: ppc-posting-board-2-proto.herokuapp.com
+  admin_contact: admin@mg.plotprotectors.org

--- a/prod_webserver_config/000-default.conf
+++ b/prod_webserver_config/000-default.conf
@@ -72,8 +72,7 @@ ServerTokens Prod
 ## Memcache settings ##
 <IfModule mod_env.c>
   SetEnv MEMCACHE_SERVERS 127.0.0.1
-  SetEnv MAIL_HOST mg.plotprotectors.org
-  SetEnv ADMIN_CONTACT admin@mg.plotprotectors.org
+  SetEnv BOARD_SITE main
 </IfModule>
 ## Passenger ##
 ## Allows us to set serverwide Passenger settings ##


### PR DESCRIPTION
Create config/sites.yml and load it into SITE_CONFIG (and define
SITE_KIND, which indicates which SITE_CONFIG entry was loaded).

Migrate all the configuration to SITE_CONFIG, which includes making
the title configurable.

This massively cuts down on environment variables - set BOARD_SITE in
the environment to pick a configuration, :devel is used if you don't
specify.