### PR TITLE
Disable caching on recently replied to threads

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -78,6 +78,10 @@ class Post < ApplicationRecord
     (Time.now - self.created_at < DAY) && (Time.now - self.root.created_at > DAY) && !self.is_root?
   end
 
+  def seeing_activity?
+    (Time.now - self.updated_at) < DAY
+  end
+
   def reSorted?
     (self.sort_timestamp - self.created_at).abs > 60
   end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -29,7 +29,7 @@
       <h3>Posts tagged: <%= tag.name %></h3>
       <% posts.each do |post| %>
         <%# Template Dependency: post/post_subject %>
-        <% cache(post, namespace: 'post_threads') do %>
+        <% cache_unless(post.seeing_activity?, post, namespace: 'post_threads') do %>
         <%= render :partial => 'thread', :locals => { :bodies => false, :id => false },
                    :object =>
                    Post.arrange_nodes(post.subtree
@@ -45,7 +45,7 @@
   <% end %>
   <% @tagged_posts[false].each do |post| %>
     <%# Template Dependency: post/post_subject %>
-    <% cache(post, namespace: 'post_threads') do %>
+    <% cache_unless(post.seeing_activity?, post, namespace: 'post_threads') do %>
     <%= render :partial => 'thread', :locals => { :bodies => false, :id => false },
       :object =>
       Post.arrange_nodes(post.subtree


### PR DESCRIPTION
This commit bluntly fixes the problem where now post indicators are
stale.  It does so by saying that a thread is not cached if someone has
replied to it in the last 24 hours. This will increase load times
somewhat, though I suspect it's unlikely more than a fifth of threads
are being replied to at any given time, and that at least some of them
are small, and so the problems will be minor in practice.

I'd appreciate better thoughts on how to do this