### PR TITLE
 Move bans to whitelisting the pages you aren't blocked from.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 class ApplicationController < ActionController::Base
   before_action :devise_permitted_parameters, if: :devise_controller?
+  before_action :ip_ban
+  before_action :check_ban
+
   @query = ""
   helper_method :flash_message
 
@@ -28,8 +31,11 @@ class ApplicationController < ActionController::Base
   def check_ban
     if user_signed_in?
       ban = Ban.find_ban(:user_id => current_user.id)
-      if  ban
-        sign_out current_user
+      if ban
+        # Signing in as a banned user is sticky until ban expiry.
+        # In the event someone actually has a problem with this
+        # have them wipe the cookie
+        # sign_out current_user
         redirect_to ban_path(ban)
       end
     end

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 class BansController < ApplicationController
-  before_action :ip_ban, :authenticate_user!, :check_ban, :except => [ :show ]
+  skip_before_action :ip_ban, :check_ban, :only => [ :show ]
+  before_action :authenticate_user!, :except => [ :show ]
   before_action :must_be_moderator!, :except => [ :show, :index ]
 
   # GET /bans

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,5 +1,12 @@
 class PagesController < ApplicationController
+  skip_before_action :ip_ban, :check_ban, :only => [:data_collection]
   def formatting_help
+    respond_to do |format|
+      format.html
+    end
+  end
+
+  def data_collection
     respond_to do |format|
       format.html
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 class PostsController < ApplicationController
   before_action :clear_return_url
-  before_action :ip_ban, :authenticate_user_board!, :check_ban,
+  skip_before_action :ip_ban, :check_ban,
+                     :except => [:new, :create, :update, :edit, :preview, :destroy]
+  before_action :authenticate_user_board!,
                 :only => [:new, :create, :update, :edit, :preview, :destroy]
   before_action :must_be_moderator!, :only => [:destroy]
   helper_method :allowed_to_edit?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,5 @@
 class UsersController < ApplicationController
-  before_action :ip_ban
   before_action :authenticate_user!
-  before_action :check_ban
   # GET /users/1
   # GET /users/1.json
   def show

--- a/app/controllers/watches_controller.rb
+++ b/app/controllers/watches_controller.rb
@@ -1,7 +1,5 @@
 class WatchesController < ApplicationController
-  before_action :ip_ban
   before_action :authenticate_user!
-  before_action :check_ban
 
   # POST /post/1/watch
   # POST /bans/1/watch.json

--- a/app/views/bans/show.html.erb
+++ b/app/views/bans/show.html.erb
@@ -18,5 +18,5 @@ that is, for
 </p>
 <p>
 If you believe you've been banned in error, please
-contact the Board admin at <&= mail_to(SITE_CONFIG[:admin_contact]) %>
+contact the Board admin at <%= mail_to(SITE_CONFIG[:admin_contact]) %>
 </p>

--- a/app/views/pages/data_collection.html.erb
+++ b/app/views/pages/data_collection.html.erb
@@ -1,3 +1,3 @@
-<% title("Formatting Help") %>
+<% title("Data collection") %>
 <h1>Data collection policy</h1>
 <%== render 'data_collection' %>


### PR DESCRIPTION
Additionally, when encountering a banned user, no longer sign them out
at ban time.

The ban whitelist has the side effect of preventing banned users from
interacting with the Devise controllers, preventing them from creating
new accounts and logging out via the UI.