### PR TITLE
Enabled email authentication for account creation via devise

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,13 +3,13 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
+  devise :database_authenticatable, :registerable, :confirmable,
          :recoverable, :rememberable, :trackable, :validatable,
          :authentication_keys => [ :name ]
 #         :openid_authenticatable #Don't feel like dealing with this
 
   before_create :de_guest
-  after_create :welcome_mail
+  after_confirmation :welcome_mail
 
   has_many :posts, dependent: :restrict_with_exception
   has_one :ban, dependent: :nullify

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,6 @@ class User < ApplicationRecord
 #         :openid_authenticatable #Don't feel like dealing with this
 
   before_create :de_guest
-  after_confirmation :welcome_mail
 
   has_many :posts, dependent: :restrict_with_exception
   has_one :ban, dependent: :nullify
@@ -33,7 +32,7 @@ class User < ApplicationRecord
     true
   end
 
-  def welcome_mail
+  def after_confirmation
     BoardMailer.welcome_email(self).deliver_now
   end
 

--- a/app/views/bans/show.html.erb
+++ b/app/views/bans/show.html.erb
@@ -4,7 +4,7 @@
 <% if @ban.user_id != nil %>
 The user <%= @ban.user.name %> is banned.
 <% end %>
-<% if @ban.ip != nil && ban.ip != "" %>
+<% if @ban.ip != nil && @ban.ip != "" %>
 The IP address <%= @ban.ip %> is banned.
 <% end %>
 The reason for this ban is: "<%= @ban.reason %>".

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -10,7 +10,7 @@
                   required: true,
                   autofocus: true,
                   value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
-                  input_html: { autocomplete: "email" %>
+                  input_html: { autocomplete: "email" } %>
     </div>
   </div>
   <div class="row">

--- a/db/migrate/20191206055529_add_confirmation_columns_to_users.rb
+++ b/db/migrate/20191206055529_add_confirmation_columns_to_users.rb
@@ -1,0 +1,25 @@
+class AddConfirmationColumnsToUsers < ActiveRecord::Migration[5.2]
+  def up
+    change_table(:users) do |t|
+      t.string   :confirmation_token
+      t.datetime :confirmed_at
+      t.datetime :confirmation_sent_at
+      t.string   :unconfirmed_email # Only if using reconfirmable
+    end
+
+    execute <<-SQL
+      update users
+      set confirmed_at = '2019-10-31 00:00:00', confirmation_token = id;
+    SQL
+
+    add_index :users, :confirmation_token,   :unique => true
+  end
+
+  def down
+    remove_index :users, :confirmation_token
+    remove_column :users, :confirmation_token
+    remove_column :users, :confirmed_at
+    remove_column :users, :confirmation_sent_at
+    remove_column :users, :unconfirmed_email # Only if using reconfirmable
+  end
+end


### PR DESCRIPTION
Testing: ran locally, created new account, inspected confirmation email by eye and confirmed via conf link:

`Devise::Mailer#confirmation_instructions: processed outbound mail in 20.1ms
Sent mail to techno.dann@gmail.com (12.7ms)
Date: Thu, 05 Dec 2019 22:09:19 -0800
From: system@localhost
Reply-To: system@localhost
To: techno.dann@gmail.com
Message-ID: <5de9f08feddd7_2ddc5ec53ec63059@DESKTOP-KD5G494.mail>
Subject: Confirmation instructions
Mime-Version: 1.0
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

<p>Welcome to the PPC, Techno-Dann! If you haven&#39;t read <a href="https://docs.google.com/document/pub?id=18hztHpDehxcfrjaXoFUew1vb0BdZPDAusHxMHzHiCzM">the Constitution</a> yet, please do so. It&#39;s important.</p>

<p>You can confirm your account through the link below:</p>

<p><a href="http://localhost:3000/users/confirmation?confirmation_token=71vQnM5ge53Sfe7ohh5H">Confirm my account</a></p>

Redirected to http://localhost:3000/
Completed 302 Found in 812ms (ActiveRecord: 4.1ms)`

Also made sure an account created pre-migration was correctly confirmed - can still log in and out correctly, and attempting to re-send a confirmation email gets a polite "already confirmed" message.

I would appreciate further testing on this one, I'm not terribly confident in my work.