### PR TITLE
Correct the markup generated for subthreads.

### DIFF
--- a/app/views/posts/_thread.html.erb
+++ b/app/views/posts/_thread.html.erb
@@ -38,9 +38,11 @@
         <br /><br />
       <% end %>
     </li>
-    <li><ul class="subthread list-unstyled">
+    <% unless subthreads.empty? %>
+    <ul class="subthread list-unstyled">
       <%= render_thread(subthreads, bodies, id) %>
-    </ul></li>
+    </ul>
+    <% end %>
 
     <% if post.poofed && bodies && !post.next_version%></div> <% end %>
   <% end %>


### PR DESCRIPTION
1. Remove empty &lt;ul&gt;s for posts with no replies.
2. Remove the spurious &lt;li&gt; surrounding subthreads.

These changes make the page look a lot better when you turn CSS off, which is probably a proxy for behaving better with screen readers and such.