### PR TITLE
Change the wording around reply emails.

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -30,7 +30,7 @@
       <%= f.input :subject, input_html: { maxlength: 100 } %>
       <%= f.input :author, input_html: { maxlength: 80 } %>
       <% if watch_checkbox %>
-        <%= f.input :watch_add, :label => "Enable reply emails", :as => :boolean,
+        <%= f.input :watch_add, :label => "Get emails about replies to this thread", :as => :boolean,
         :wrapper => :board_vertical_boolean,
         :input_html => { checked: false },
         :disabled => @post.ancestors.joins("INNER JOIN posts_users on posts_users.post_id = posts.id")

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -8,9 +8,9 @@
     <% end %>
     <% if user_signed_in? %>
       <% if current_user.watched_posts.exists?(@post.id) %>
-        <%= link_to 'Disable reply emails', "/posts/#{@post.id}/watch", :method => :delete, :class => "btn btn-default", :role => "button" %>
+        <%= link_to 'Stop reply notifications', "/posts/#{@post.id}/watch", :method => :delete, :class => "btn btn-default", :role => "button" %>
       <% else %>
-        <%= link_to 'Enable reply emails', "/posts/#{@post.id}/watch", :method => :post, :class => 'btn btn-default', :role => "button" %>
+        <%= link_to 'Get emails on replies', "/posts/#{@post.id}/watch", :method => :post, :class => 'btn btn-default', :role => "button" %>
       <% end %>
     <% end %>
     <% if cookies[:last_subforum] %>


### PR DESCRIPTION
This is per discussion in the Discord last Sunday where someone
pointed out "Enable reply emails" was ambiguous.