### PR TITLE
Add reply count to post subject

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,21 +2,21 @@
 <html>
 <head>
   <title><%= content_for(:title) ? yield(:title) : "Index" %>
-         - <%= SITE_CONFIG[:title] %></title>
+    - <%= SITE_CONFIG[:title] %></title>
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <%= stylesheet_link_tag    "application", :media => "all" %>
-  <%= jquery_include_tag :google  %>
+  <%= stylesheet_link_tag "application", :media => "all" %>
+  <%= jquery_include_tag :google %>
   <%= javascript_include_tag "application" %>
-  <link rel="shortcut icon" href="/favicon.ico" />
+  <link rel="shortcut icon" href="/favicon.ico"/>
   <%= csrf_meta_tags %>
   <%= auto_discovery_link_tag(:atom, posts_url(:atom)) %>
   <% if current_user %>
     <style media="all" type="text/css">
-      span.author-tag-for-<%= current_user.id %> {
-          font-weight: bold;
-      }
+        span.author-tag-for-<%= current_user.id %> {
+            font-weight: bold;
+        }
     </style>
   <% end %>
   <!--[if lt IE 9]>
@@ -64,7 +64,7 @@
     </div>
   </div>
 </nav>
-<%= render :partial => 'layouts/information', :locals => { :flash => flash } %>
+<%= render :partial => 'layouts/information', :locals => {:flash => flash} %>
 <% flash[:info] = [] %>
 <div id="main" role="main">
   <%= yield %>
@@ -72,7 +72,7 @@
     <footer class="col-sm-6 col-md-offset-3">
       <p>
         This software is licensed under the
-        <%= link_to "GNU Affero GPL version 3 or later", "http://www.gnu.org/licenses/agpl-3.0.html" =%>.
+        <%= link_to "GNU Affero GPL version 3 or later", "http://www.gnu.org/licenses/agpl-3.0.html" %>.
         Source code is located <%= link_to "at Github", "https://github.com/TechnoDann/PPC-board-2.0" %>.
       </p>
       <p>

--- a/app/views/posts/_post_subject.html.erb
+++ b/app/views/posts/_post_subject.html.erb
@@ -1,14 +1,17 @@
 <% post = post_subject %>
 <% cache_unless(post.recent?, post, namespace: 'post_subject', expires_in: 72.hours, race_condition_ttl: 30.seconds) do %>
-<span class="short-post-subject"><%= link_to raw(htmlic_title(post.subject)), post %></span> by
-<span class="short-post-author author-tag-for-<%= post.user_id %>"><%= post.author %></span>
-<span class="short-post-time">on <%= post.created_at %></span>
-<%= raw '<span class="badge" label="New post" title="New post">&nbsp;</span>' if post.new_reply? %>
-<%= raw '<span class="label label-warning">Locked</span>' if post.locked %>
-<%= raw '<span class="label label-danger">Poofed</span>' if post.poofed %>
-<%= raw '<span class="label label-info">Edited</span>' if post.previous_version %>
-<%= raw '<span class="label label-important">Previous Version</span>' if post.next_version %>
-<% post.tags.each do |tag| %>
-<span class="label label-default short-post-tag"><%= tag.name %></span>
-<% end %>
+  <span class="short-post-subject"><%= link_to raw(htmlic_title(post.subject)), post %></span> by
+  <span class="short-post-author author-tag-for-<%= post.user_id %>"><%= post.author %></span>
+  <span class="short-post-time">on <%= post.created_at %></span>
+  <%= raw '<span class="badge" label="New post" title="New post">&nbsp;</span>' if post.new_reply? %>
+  <%= raw '<span class="label label-warning">Locked</span>' if post.locked %>
+  <%= raw '<span class="label label-danger">Poofed</span>' if post.poofed %>
+  <%= raw '<span class="label label-info">Edited</span>' if post.previous_version %>
+  <%= raw '<span class="label label-important">Previous Version</span>' if post.next_version %>
+  <% unless post.has_parent? %>
+    <span class="label label-primary"><%= post.descendant_ids.length %> replies</span>
+  <% end %>
+  <% post.tags.each do |tag| %>
+    <span class="label label-default short-post-tag"><%= tag.name %></span>
+  <% end %>
 <% end %>


### PR DESCRIPTION
This change will accommodate a feature mentioned here: https://www.plotprotectors.org/posts/158171

Update currently looks at the post subject and adds a tag marked 'label-primary' if it is a top-level post subject, using the existing number of descendant IDs.