### PR TITLE
Make the "Return to messages" button link to root of viewed post

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -14,9 +14,9 @@
       <% end %>
     <% end %>
     <% if cookies[:last_subforum] %>
-      <%= link_to 'Return to messages', "/posts/tagged/#{cookies[:last_subforum]}", :class => 'btn btn-default', :role => "button" %>
+      <%= link_to 'Return to messages', "/posts/tagged/#{cookies[:last_subforum]}#post-#{@post.root.id}", :class => 'btn btn-default', :role => "button" %>
     <% else %>
-      <%= link_to 'Return to messages', posts_path, :class => 'btn btn-default', :role => "button" %>
+      <%= link_to 'Return to messages', posts_path(anchor: "post-#{@post.root.id}"), :class => 'btn btn-default', :role => "button" %>
     <% end %>
   <% end %>
   <% if user_signed_in? && current_user.moderator? %>

--- a/app/views/posts/tagged.html.erb
+++ b/app/views/posts/tagged.html.erb
@@ -16,7 +16,7 @@
 <%= render 'header' %>
 
 <% @posts.each do |post| %>
-  <div class="post thread">
+  <div class="post thread" id="post-<%= post.id %>">
     <% new_post_count = post.subtree.select(&:recent?).count %>
     <% if new_post_count > 0 %>
       <span class="badge" label="<%= new_post_count %> new post".pluralize(new_post_count)
@@ -26,6 +26,6 @@
   </div>
 <% end %>
 <br />
-<%= render :partial => 'new_post_button', 
+<%= render :partial => 'new_post_button',
            :locals => { :tag => @tag && @tag.id, :style => " "} %>
 <%= will_paginate @raw_posts %>


### PR DESCRIPTION
This adresses a feature request from
https://www.plotprotectors.org/posts/166814
. Note that, unlike on the former Board, this doesn't work for threads
not on the front page (which was, IMO, a rare usecase).

This also adds #post-NNNN IDs to subforum view to enable this fearuter.