### PR TITLE
The minimal steps neeeded to handle the RP Board's mail going forward.

### DIFF
--- a/config/sites.yml
+++ b/config/sites.yml
@@ -10,4 +10,5 @@ main:
 rp:
   title: PPC Roleplay Board
   app_host: ppc-posting-board-2-proto.herokuapp.com
+  mail_host: rpmail.plotprotectors.org
   admin_contact: admin@mg.plotprotectors.org


### PR DESCRIPTION
On top of these changes, we'll need to do some stuff with Sendgrid that involves setting up DNS records on rpmail.plotprotectors.org .